### PR TITLE
Build and deploy npm demos to GitHub Pages

### DIFF
--- a/.github/demo-deployment.md
+++ b/.github/demo-deployment.md
@@ -1,0 +1,26 @@
+# Demo deployment setup
+
+The [`deploy-demos.yml`](workflows/deploy-demos.yml) workflow builds the four
+deployable projects in `examples-npm/` on every push to `main`. It also runs on
+pull requests so the demo builds are checked before merging, and it can be run
+manually with `workflow_dispatch`.
+
+Each demo is uploaded as a separate seven-day GitHub Actions artifact:
+
+- `demo-OpenStreetMap-Endless`
+- `demo-OpenStreetMap-HelloWorld`
+- `demo-OpenStreetMap-UserData-RealScale`
+- `demo-mapbox-terrain`
+
+The final deployment job is intentionally disabled until the hosting provider
+is selected. When the host and authentication are available:
+
+1. Create the `demos` GitHub Environment.
+2. Add the repository variable `DEMO_DEPLOY_ENABLED=true`.
+3. Add the host as `DEMO_DEPLOY_HOST` and the credential as the environment
+   secret `DEMO_DEPLOY_TOKEN`.
+4. Replace the provider hook in the workflow with the host-specific deploy
+   command. It receives the demo name in `DEMO_NAME` and the built files in
+   `DEMO_DIST`.
+
+No host or credential is committed to the repository.

--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>babylonjs-mapping demos</title>
+    <style>
+      :root { color-scheme: light dark; font: 1rem/1.5 system-ui, sans-serif; }
+      body { max-width: 48rem; margin: 4rem auto; padding: 0 1rem; }
+      a { display: block; margin: 0.75rem 0; }
+    </style>
+  </head>
+  <body>
+    <h1>babylonjs-mapping demos</h1>
+    <p>Live Babylon.js mapping examples built from this repository.</p>
+    <a href="OpenStreetMap-HelloWorld/">OpenStreetMap Hello World</a>
+    <a href="OpenStreetMap-Endless/">OpenStreetMap Endless</a>
+    <a href="OpenStreetMap-UserData-RealScale/">OpenStreetMap User Data</a>
+    <a href="mapbox-terrain/">Mapbox Terrain</a>
+  </body>
+</html>

--- a/.github/workflows/deploy-demos.yml
+++ b/.github/workflows/deploy-demos.yml
@@ -1,0 +1,93 @@
+name: Build and deploy demo environments
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: demo-deployment-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "22"
+
+jobs:
+  build:
+    name: Build ${{ matrix.demo }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        demo:
+          - OpenStreetMap-Endless
+          - OpenStreetMap-HelloWorld
+          - OpenStreetMap-UserData-RealScale
+          - mapbox-terrain
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      # The npm demos do not have lockfiles yet, so npm install is intentional.
+      - name: Install demo dependencies
+        working-directory: examples-npm/${{ matrix.demo }}
+        run: npm install --no-package-lock --no-audit --no-fund
+
+      - name: Build demo
+        working-directory: examples-npm/${{ matrix.demo }}
+        run: npm run build
+
+      - name: Upload built demo
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-${{ matrix.demo }}
+          path: examples-npm/${{ matrix.demo }}/dist
+          if-no-files-found: error
+          retention-days: 7
+
+  # This job is deliberately gated until a hosting provider and credentials are
+  # available. It provides the provider-neutral handoff point for the deployer.
+  deploy:
+    name: Deploy ${{ matrix.demo }}
+    if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && vars.DEMO_DEPLOY_ENABLED == 'true' }}
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        demo:
+          - OpenStreetMap-Endless
+          - OpenStreetMap-HelloWorld
+          - OpenStreetMap-UserData-RealScale
+          - mapbox-terrain
+    environment:
+      name: demos
+
+    steps:
+      - name: Download built demo
+        uses: actions/download-artifact@v4
+        with:
+          name: demo-${{ matrix.demo }}
+          path: dist
+
+      - name: Deploy demo (provider hook)
+        env:
+          DEMO_NAME: ${{ matrix.demo }}
+          DEMO_DIST: ${{ github.workspace }}/dist
+          DEMO_DEPLOY_HOST: ${{ vars.DEMO_DEPLOY_HOST }}
+          DEMO_DEPLOY_TOKEN: ${{ secrets.DEMO_DEPLOY_TOKEN }}
+        run: |
+          echo "::error::No demo deployment provider is configured yet for ${DEMO_NAME}."
+          echo "Replace this provider hook after DEMO_DEPLOY_HOST and DEMO_DEPLOY_TOKEN are available."
+          exit 1

--- a/.github/workflows/deploy-demos.yml
+++ b/.github/workflows/deploy-demos.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
   group: demo-deployment-${{ github.ref }}
   cancel-in-progress: true
@@ -19,16 +16,10 @@ env:
 
 jobs:
   build:
-    name: Build ${{ matrix.demo }}
+    name: Build demos
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        demo:
-          - OpenStreetMap-Endless
-          - OpenStreetMap-HelloWorld
-          - OpenStreetMap-UserData-RealScale
-          - mapbox-terrain
+    permissions:
+      contents: read
 
     steps:
       - name: Check out repository
@@ -39,55 +30,67 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      # The npm demos do not have lockfiles yet, so npm install is intentional.
-      - name: Install demo dependencies
-        working-directory: examples-npm/${{ matrix.demo }}
-        run: npm install --no-package-lock --no-audit --no-fund
+      - name: Build and pack current library
+        run: |
+          npm ci
+          npm run build
+          npm pack --pack-destination "${RUNNER_TEMP}"
 
-      - name: Build demo
-        working-directory: examples-npm/${{ matrix.demo }}
-        run: npm run build
+      - name: Build demo site
+        env:
+          OSMB_ACCESS_TOKEN: ${{ secrets.OSMB_ACCESS_TOKEN }}
+          MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p site
+          package_tarball="$(find "${RUNNER_TEMP}" -maxdepth 1 -name 'babylonjs-mapping-*.tgz' -print -quit)"
+          test -n "${package_tarball}"
 
-      - name: Upload built demo
-        uses: actions/upload-artifact@v4
+          demos=(
+            OpenStreetMap-Endless
+            OpenStreetMap-HelloWorld
+            OpenStreetMap-UserData-RealScale
+            mapbox-terrain
+          )
+
+          for demo in "${demos[@]}"; do
+            cd "${GITHUB_WORKSPACE}/examples-npm/${demo}"
+            npm install --no-package-lock --no-audit --no-fund
+            npm install "${package_tarball}" --no-save --no-package-lock --no-audit --no-fund
+            npm run build
+
+            mkdir -p "${GITHUB_WORKSPACE}/site/${demo}"
+            cp -R dist/. "${GITHUB_WORKSPACE}/site/${demo}/"
+
+            if [[ -n "${OSMB_ACCESS_TOKEN}" && "${demo}" != "mapbox-terrain" ]]; then
+              printf '%s' "${OSMB_ACCESS_TOKEN}" > "${GITHUB_WORKSPACE}/site/${demo}/osmb-key.txt"
+            fi
+            if [[ -n "${MAPBOX_ACCESS_TOKEN}" && "${demo}" == "mapbox-terrain" ]]; then
+              printf '%s' "${MAPBOX_ACCESS_TOKEN}" > "${GITHUB_WORKSPACE}/site/${demo}/mapbox-key.txt"
+            fi
+          done
+
+          cp "${GITHUB_WORKSPACE}/.github/pages/index.html" "${GITHUB_WORKSPACE}/site/index.html"
+          touch "${GITHUB_WORKSPACE}/site/.nojekyll"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: demo-${{ matrix.demo }}
-          path: examples-npm/${{ matrix.demo }}/dist
-          if-no-files-found: error
-          retention-days: 7
+          path: site
 
-  # This job is deliberately gated until a hosting provider and credentials are
-  # available. It provides the provider-neutral handoff point for the deployer.
   deploy:
-    name: Deploy ${{ matrix.demo }}
-    if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && vars.DEMO_DEPLOY_ENABLED == 'true' }}
+    name: Deploy demos to GitHub Pages
+    if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
     needs: build
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        demo:
-          - OpenStreetMap-Endless
-          - OpenStreetMap-HelloWorld
-          - OpenStreetMap-UserData-RealScale
-          - mapbox-terrain
+    permissions:
+      pages: write
+      id-token: write
     environment:
-      name: demos
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - name: Download built demo
-        uses: actions/download-artifact@v4
-        with:
-          name: demo-${{ matrix.demo }}
-          path: dist
-
-      - name: Deploy demo (provider hook)
-        env:
-          DEMO_NAME: ${{ matrix.demo }}
-          DEMO_DIST: ${{ github.workspace }}/dist
-          DEMO_DEPLOY_HOST: ${{ vars.DEMO_DEPLOY_HOST }}
-          DEMO_DEPLOY_TOKEN: ${{ secrets.DEMO_DEPLOY_TOKEN }}
-        run: |
-          echo "::error::No demo deployment provider is configured yet for ${DEMO_NAME}."
-          echo "Replace this provider hook after DEMO_DEPLOY_HOST and DEMO_DEPLOY_TOKEN are available."
-          exit 1
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-demos.yml
+++ b/.github/workflows/deploy-demos.yml
@@ -55,7 +55,6 @@ jobs:
 
           for demo in "${demos[@]}"; do
             cd "${GITHUB_WORKSPACE}/examples-npm/${demo}"
-            npm install --no-package-lock --no-audit --no-fund
             npm install "${package_tarball}" --no-save --no-package-lock --no-audit --no-fund
             npm run build
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ runs the tests and build first, then publishes with npm provenance. Before
 creating the release, configure npm's trusted publisher for repository
 `djzielin/babylonjs-mapping` and workflow file `publish-npm.yml`.
 
+## GitHub Pages demos
+
+The four npm examples are built and published to GitHub Pages from `main` by
+GitHub Actions. The workflow keeps the demos under separate paths and exposes
+an index page linking to each one. Add the repository's `OSMB_ACCESS_TOKEN` and
+`MAPBOX_ACCESS_TOKEN` Actions secrets if the live building and terrain data
+should be enabled; builds remain useful without those optional credentials.
+
 ## Building geometry options
 
 Call `createGeometry` and `updateRaster` before generating buildings. The library throws

--- a/tsconfig.npm.json
+++ b/tsconfig.npm.json
@@ -18,7 +18,7 @@
     "skipLibCheck": true,
     "removeComments": false,
     "preserveConstEnums": true,
-    "lib": ["es5", "dom", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "es2020.bigint", "es2017"],
+    "lib": ["es5", "dom", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "es2018.promise", "es2020.bigint", "es2020.string", "es2017"],
     "outDir": "./lib"
   },
   "include": [


### PR DESCRIPTION
Closes #92
Closes #77

## Summary

- build the current package from source and pack it before compiling the npm examples
- build all four examples into one GitHub Pages artifact under stable per-demo paths
- publish a linked index page and deploy it automatically from `main` with the Pages actions
- optionally copy `OSMB_ACCESS_TOKEN` and `MAPBOX_ACCESS_TOKEN` repository secrets into the public demo roots
- retain pull-request builds without deploying them

Using the repository's packed tarball fixes the stale-registry export mismatch that previously prevented the npm Hello World and Endless examples from compiling against the current package.

## Validation

- built all four examples locally against `babylonjs-mapping-1.1.43.tgz`
- verified the assembled Pages site contains an index and all four demo entry points
- `git diff --check`
