### PR TITLE
Update examples for Duke and package-root imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The "Hello World" of creating an OpenStreetMap tileset, along with extruded buil
     this.ourTS = new TileSet(this.scene,this.engine);
     this.ourTS.setRasterProvider(new RasterOSM(this.ourTS)); //set basemap to pull from Open Street Maps
     this.ourTS.createGeometry(new Vector2(4,4), 20, 2); //4x4 tile set, 20m width of each tile, and 2 divisions on each tile
-    this.ourTS.updateRaster(35.2258461, -80.8400777, 16); //lat, lon, zoom. takes us to charlotte. 
+    this.ourTS.updateRaster(36.0014, -78.9382, 16); //lat, lon, zoom. takes us to Duke University in Durham.
 
     this.ourOSM=new BuildingsOSM(this.ourTS); //lets pull building footprints from Open Street Map Buildings
     this.ourOSM.accessToken=accessToken;      //now requires Auth token

--- a/examples-local/hello-world/src/index.ts
+++ b/examples-local/hello-world/src/index.ts
@@ -121,7 +121,7 @@ class Game {
         this.ourTS = new TileSet(this.scene,this.engine);
         this.ourTS.setRasterProvider(new RasterOSM(this.ourTS)); //raster basemap to OSM
         this.ourTS.createGeometry(new Vector2(4,4), 25, 2); //4x4 tile set, 20m width of each tile, and 2 divisions on each tile
-        this.ourTS.updateRaster(35.2258461, -80.8400777, 16); //lat, lon, zoom. takes us to charlotte. 
+        this.ourTS.updateRaster(36.0014, -78.9382, 16); //lat, lon, zoom. takes us to Duke University in Durham.
         this.ourTileMath=new TileMath(this.ourTS);
 
         const accessToken=await this.getKey("osmb-key.txt");

--- a/examples-npm/OpenStreetMap-Endless/src/index.ts
+++ b/examples-npm/OpenStreetMap-Endless/src/index.ts
@@ -23,9 +23,7 @@ import { Control } from "@babylonjs/gui";
 import "@babylonjs/core/Materials/standardMaterial"
 import "@babylonjs/inspector";
 
-import BuildingsOSM from "babylonjs-mapping/lib/BuildingsOSM";
-import TileSet from "babylonjs-mapping";
-import RasterOSM from "babylonjs-mapping/lib/RasterOSM";
+import { BuildingsOSM, RasterOSM, TileSet } from "babylonjs-mapping";
 
 class Game {
     private canvas: HTMLCanvasElement;

--- a/examples-npm/OpenStreetMap-HelloWorld/src/index.ts
+++ b/examples-npm/OpenStreetMap-HelloWorld/src/index.ts
@@ -21,9 +21,7 @@ import { Control } from "@babylonjs/gui";
 import "@babylonjs/core/Materials/standardMaterial"
 import "@babylonjs/inspector";
 
-import TileSet from "babylonjs-mapping";
-import BuildingsOSM from "babylonjs-mapping/lib/BuildingsOSM";
-import RasterOSM from "babylonjs-mapping/lib/RasterOSM";
+import { BuildingsOSM, RasterOSM, TileSet } from "babylonjs-mapping";
 
 class Game {
     private canvas: HTMLCanvasElement;
@@ -117,7 +115,7 @@ class Game {
         this.ourTS = new TileSet(this.scene,this.engine);
         this.ourTS.setRasterProvider(new RasterOSM(this.ourTS)); //raster basemap to OSM
         this.ourTS.createGeometry(new Vector2(4,4), 20, 2); //4x4 tile set, 20m width of each tile, and 2 divisions on each tile
-        this.ourTS.updateRaster(35.2258461, -80.8400777, 16); //lat, lon, zoom. takes us to charlotte. 
+        this.ourTS.updateRaster(36.0014, -78.9382, 16); //lat, lon, zoom. takes us to Duke University in Durham.
 
         const accessToken=await this.getKey("osmb-key.txt");
         this.ourOSM=new BuildingsOSM(this.ourTS);

--- a/examples-npm/OpenStreetMap-UserData-RealScale/src/index.ts
+++ b/examples-npm/OpenStreetMap-UserData-RealScale/src/index.ts
@@ -34,10 +34,7 @@ import CsvData from "./CsvData";
 //import OpenStreetMap from "./babylonjs-mapping/OpenStreetMap";
 //import MapBox from "./babylonjs-mapping/MapBox";
 
-import TileSet from "babylonjs-mapping";
-import BuildingsOSM from "babylonjs-mapping/lib/BuildingsOSM";
-import { EPSG_Type } from "babylonjs-mapping/lib/TileMath";
-import RasterOSM from "babylonjs-mapping/lib/RasterOSM";
+import { BuildingsOSM, EPSG_Type, RasterOSM, TileSet } from "babylonjs-mapping";
 
 class Game {
     private canvas: HTMLCanvasElement;

--- a/examples-npm/mapbox-terrain/src/index.ts
+++ b/examples-npm/mapbox-terrain/src/index.ts
@@ -27,8 +27,7 @@ import "@babylonjs/core/Materials/standardMaterial"
 import "@babylonjs/inspector";
 import '@babylonjs/core/Debug/debugLayer';
 
-import TileSet from "babylonjs-mapping";
-import RasterMB from "babylonjs-mapping/lib/RasterMB";
+import { RasterMB, TileSet } from "babylonjs-mapping";
 
 class Game {
     private canvas: HTMLCanvasElement;


### PR DESCRIPTION
Fixes #82
Closes #76

## Summary

- point the README and local Hello World example at Duke University in Durham
- update the npm Hello World example to use the same Duke location
- replace legacy `babylonjs-mapping/lib/*` imports in all four npm examples with named imports from the package root
- keep the npm examples aligned with the repository’s current exports map

## Validation

- `npm test -- --reporter=dot`
- `npm run build`
- `examples-local/hello-world: npm run build`
- built all four npm examples against a locally packed current package

The npm registry’s current `1.1.43` artifact still contains the legacy package layout, so registry-based demo installs remain dependent on the separate publishing work tracked in #77.
