### PR TITLE
Detect GeoJSON coordinate reference systems

### DIFF
--- a/src/buildings/Buildings.ts
+++ b/src/buildings/Buildings.ts
@@ -108,6 +108,7 @@ export default abstract class Buildings {
 
         let index = 0;
         let addedBuildings = 0;
+        const detectedEpsgType = request.epsgType ?? GeoJSON.detectProjection(topLevel);
         const meshArray: Mesh[] = [];
         for (const f of topLevel.features) {
             const brequest: BuildingRequest = {
@@ -115,7 +116,7 @@ export default abstract class Buildings {
                 tile: request.tile,
                 tileCoords: request.tile.tileCoords.clone(),
                 inProgress: false,
-                epsgType: request.epsgType,
+                epsgType: detectedEpsgType,
                 feature: f,
                 flipWinding: request.flipWinding
             }

--- a/src/buildings/GeoJSON.ts
+++ b/src/buildings/GeoJSON.ts
@@ -15,6 +15,16 @@ import TileBuilding from "../core/TileBuilding.js";
 export interface topLevel {
     "type": string;
     "features": feature[];
+    "crs"?: coordinateReferenceSystem | string | null;
+}
+
+export interface coordinateReferenceSystem {
+    "type"?: string;
+    "properties"?: {
+        "name"?: string;
+        "href"?: string;
+        "code"?: string | number;
+    };
 }
 
 export interface feature {
@@ -43,6 +53,55 @@ export interface coordinatePair extends Array<number> { }
 
 export interface coordinateArray extends Array<Vector3> { }
 export interface coordinateArrayOfArrays extends Array<coordinateArray> { }
+
+function projectionFromIdentifier(identifier: unknown): EPSG_Type | undefined {
+    if (typeof identifier === "number") {
+        if (identifier === 4326) {
+            return EPSG_Type.EPSG_4326;
+        }
+        if (identifier === 3857 || identifier === 900913 || identifier === 3785 || identifier === 102100 || identifier === 102113) {
+            return EPSG_Type.EPSG_3857;
+        }
+        return undefined;
+    }
+
+    if (typeof identifier !== "string") {
+        return undefined;
+    }
+
+    const normalized = identifier.trim().toUpperCase();
+    if (normalized === "CRS84" || normalized.endsWith("CRS84")) {
+        return EPSG_Type.EPSG_4326;
+    }
+
+    const codeMatch = normalized.match(/(?:^|[^0-9])(4326|3857|900913|3785|102100|102113)(?:$|[^0-9])/);
+    if (!codeMatch) {
+        return undefined;
+    }
+
+    return projectionFromIdentifier(Number(codeMatch[1]));
+}
+
+/**
+ * Detects the supported coordinate system declared by a GeoJSON CRS entry.
+ * Returns undefined for missing or unsupported CRS declarations so callers can
+ * preserve their existing explicit-projection fallback.
+ */
+export function detectProjection(document: Pick<topLevel, "crs">): EPSG_Type | undefined {
+    const crs = document.crs;
+    if (typeof crs === "string") {
+        return projectionFromIdentifier(crs);
+    }
+    if (crs === null || crs === undefined) {
+        return undefined;
+    }
+
+    const properties = crs.properties;
+    return projectionFromIdentifier(properties?.name)
+        ?? projectionFromIdentifier(properties?.href)
+        ?? projectionFromIdentifier(properties?.code)
+        ?? projectionFromIdentifier(crs.type);
+}
 
 export class GeoJSON {
     constructor(private tileSet: TileSet, private scene: Scene) {

--- a/tests/IssueFixes.test.ts
+++ b/tests/IssueFixes.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { NullEngine, Scene, StandardMaterial, Vector2 } from "@babylonjs/core";
 
-import { GeoJSON, type feature } from "../src/GeoJSON";
-import Buildings from "../src/Buildings";
+import { detectProjection, GeoJSON, type feature, type topLevel } from "../src/GeoJSON";
+import Buildings, { BuildingRequestType, type BuildingRequest } from "../src/Buildings";
 import TileSet from "../src/TileSet";
 import { EPSG_Type } from "../src/TileMath";
 import { RetrievalLocation, RetrievalType } from "../src/Retrieval";
@@ -21,6 +21,10 @@ class TestBuildings extends Buildings {
 
   public SubmitLoadAllRequest(): void {
     // The request queue is not part of these lifecycle tests.
+  }
+
+  public getQueuedRequests(): BuildingRequest[] {
+    return this.buildingRequests;
   }
 }
 
@@ -93,6 +97,74 @@ describe("geometry lifecycle safeguards", () => {
     expect(() => buildings.generateBuildings()).toThrow(
       "Cannot generate buildings before updateRaster() has been called.",
     );
+
+    scene.dispose();
+    engine.dispose();
+  });
+});
+
+describe("GeoJSON projection detection", () => {
+  it("recognizes common CRS declarations", () => {
+    const declarations: Array<[topLevel["crs"], EPSG_Type | undefined]> = [
+      [{ type: "name", properties: { name: "EPSG:4326" } }, EPSG_Type.EPSG_4326],
+      [{ type: "name", properties: { href: "https://www.opengis.net/def/crs/EPSG/0/3857" } }, EPSG_Type.EPSG_3857],
+      [{ type: "EPSG", properties: { code: 4326 } }, EPSG_Type.EPSG_4326],
+      [{ type: "name", properties: { name: "EPSG:9999" } }, undefined],
+      [undefined, undefined],
+    ];
+
+    for (const [crs, expected] of declarations) {
+      expect(detectProjection({ crs })).toBe(expected);
+    }
+  });
+
+  it("uses the detected CRS when queuing features without an explicit projection", () => {
+    const { engine, scene, tileSet } = createTileSet();
+    const buildings = new TestBuildings("test", tileSet, RetrievalLocation.Local);
+    const tile = tileSet.ourTiles[0];
+    const request: BuildingRequest = {
+      requestType: BuildingRequestType.LoadTile,
+      tile,
+      tileCoords: tile.tileCoords.clone(),
+      inProgress: false,
+      flipWinding: false,
+    };
+    const document: topLevel = {
+      type: "FeatureCollection",
+      crs: { type: "name", properties: { name: "EPSG:3857" } },
+      features: [createFeature({ type: "Point", coordinates: [0, 0] })],
+    };
+
+    buildings.ProcessGeoJSON(request, document);
+
+    expect(buildings.getQueuedRequests()).toHaveLength(1);
+    expect(buildings.getQueuedRequests()[0].epsgType).toBe(EPSG_Type.EPSG_3857);
+
+    scene.dispose();
+    engine.dispose();
+  });
+
+  it("keeps an explicitly supplied projection ahead of the CRS declaration", () => {
+    const { engine, scene, tileSet } = createTileSet();
+    const buildings = new TestBuildings("test", tileSet, RetrievalLocation.Local);
+    const tile = tileSet.ourTiles[0];
+    const request: BuildingRequest = {
+      requestType: BuildingRequestType.LoadTile,
+      tile,
+      tileCoords: tile.tileCoords.clone(),
+      inProgress: false,
+      flipWinding: false,
+      epsgType: EPSG_Type.EPSG_4326,
+    };
+    const document: topLevel = {
+      type: "FeatureCollection",
+      crs: { type: "name", properties: { name: "EPSG:3857" } },
+      features: [createFeature({ type: "Point", coordinates: [0, 0] })],
+    };
+
+    buildings.ProcessGeoJSON(request, document);
+
+    expect(buildings.getQueuedRequests()[0].epsgType).toBe(EPSG_Type.EPSG_4326);
 
     scene.dispose();
     engine.dispose();


### PR DESCRIPTION
Fixes #21

## Summary

- add typed support for GeoJSON `crs` declarations
- detect EPSG:4326, EPSG:3857, common Web Mercator aliases, and CRS84 identifiers
- use a detected projection when building requests do not already provide one
- preserve explicit provider projection settings
- add unit and request-queue regression coverage

## Validation

- `npm test -- --reporter=dot` (26 tests)
- `npm run build`
- `git diff --check`
