### PR TITLE
Use focused Babylon.js imports to reduce bundle overhead

### DIFF
--- a/examples-local/hello-world/src/index.ts
+++ b/examples-local/hello-world/src/index.ts
@@ -15,8 +15,8 @@ import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { Button } from "@babylonjs/gui/2D/controls/button";
-import { TextBlock } from "@babylonjs/gui";
-import { Control } from "@babylonjs/gui";
+import { TextBlock } from "@babylonjs/gui/2D/controls/textBlock";
+import { Control } from "@babylonjs/gui/2D/controls/control";
 
 import "@babylonjs/core/Materials/standardMaterial"
 import "@babylonjs/inspector";

--- a/examples-local/line-test/src/index.ts
+++ b/examples-local/line-test/src/index.ts
@@ -15,11 +15,11 @@ import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { Button } from "@babylonjs/gui/2D/controls/button";
-import { TextBlock } from "@babylonjs/gui";
-import { Control } from "@babylonjs/gui";
-import { StandardMaterial } from "@babylonjs/core";
+import { TextBlock } from "@babylonjs/gui/2D/controls/textBlock";
+import { Control } from "@babylonjs/gui/2D/controls/control";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { Color3 } from "@babylonjs/core/Maths/math";
-import { DynamicTexture } from "@babylonjs/core";
+import { DynamicTexture } from "@babylonjs/core/Materials/Textures/dynamicTexture";
 import { Matrix } from "@babylonjs/core/Maths/math";
 import "@babylonjs/core/Materials/standardMaterial"
 import "@babylonjs/inspector";
@@ -32,7 +32,7 @@ import BuildingsWFS from "../../../lib/BuildingsWFS";
 import { EPSG_Type } from "../../../lib/TileMath";
 import TileBuilding from "../../../lib/TileBuilding";
 import { coordinateArray, coordinateArrayOfArrays } from "../../../lib/GeoJSON";
-import { MeshBuilder } from "@babylonjs/core";
+import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
 import {LineTestReturnPacket} from "../../../lib/TileBuilding";
 
 class Game {

--- a/examples-local/local-load/src/index.ts
+++ b/examples-local/local-load/src/index.ts
@@ -16,9 +16,9 @@ import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { Button } from "@babylonjs/gui/2D/controls/button";
-import { TextBlock } from "@babylonjs/gui";
-import { Control } from "@babylonjs/gui";
-import { StandardMaterial } from "@babylonjs/core";
+import { TextBlock } from "@babylonjs/gui/2D/controls/textBlock";
+import { Control } from "@babylonjs/gui/2D/controls/control";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import "@babylonjs/core/Materials/standardMaterial"
 import "@babylonjs/inspector";
 

--- a/examples-local/mouse-latlon/src/index.ts
+++ b/examples-local/mouse-latlon/src/index.ts
@@ -15,10 +15,10 @@ import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { Button } from "@babylonjs/gui/2D/controls/button";
-import { TextBlock } from "@babylonjs/gui";
-import { Control } from "@babylonjs/gui";
-import { StandardMaterial } from "@babylonjs/core";
-import { MeshBuilder } from "@babylonjs/core";
+import { TextBlock } from "@babylonjs/gui/2D/controls/textBlock";
+import { Control } from "@babylonjs/gui/2D/controls/control";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
 import {EPSG_Type} from "../../../lib/TileMath"; 
 
 import "@babylonjs/core/Materials/standardMaterial"

--- a/examples-local/multisource/src/index.ts
+++ b/examples-local/multisource/src/index.ts
@@ -16,9 +16,9 @@ import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { Button } from "@babylonjs/gui/2D/controls/button";
-import { TextBlock } from "@babylonjs/gui";
-import { Control } from "@babylonjs/gui";
-import { StandardMaterial } from "@babylonjs/core";
+import { TextBlock } from "@babylonjs/gui/2D/controls/textBlock";
+import { Control } from "@babylonjs/gui/2D/controls/control";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import "@babylonjs/core/Materials/standardMaterial"
 import "@babylonjs/inspector";
 

--- a/examples-local/point-test/src/index.ts
+++ b/examples-local/point-test/src/index.ts
@@ -15,14 +15,14 @@ import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { Button } from "@babylonjs/gui/2D/controls/button";
-import { TextBlock } from "@babylonjs/gui";
-import { Control } from "@babylonjs/gui";
-import { StandardMaterial } from "@babylonjs/core";
+import { TextBlock } from "@babylonjs/gui/2D/controls/textBlock";
+import { Control } from "@babylonjs/gui/2D/controls/control";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { Color3 } from "@babylonjs/core/Maths/math";
-import { DynamicTexture } from "@babylonjs/core";
+import { DynamicTexture } from "@babylonjs/core/Materials/Textures/dynamicTexture";
 import { Matrix } from "@babylonjs/core/Maths/math";
-import { ActionManager } from "@babylonjs/core";
-import { ExecuteCodeAction } from "@babylonjs/core";
+import { ActionManager } from "@babylonjs/core/Actions/actionManager";
+import { ExecuteCodeAction } from "@babylonjs/core/Actions/directActions";
 import "@babylonjs/core/Materials/standardMaterial"
 import "@babylonjs/inspector";
 
@@ -34,7 +34,7 @@ import BuildingsWFS from "../../../lib/BuildingsWFS";
 import { EPSG_Type } from "../../../lib/TileMath";
 import TileBuilding from "../../../lib/TileBuilding";
 import { coordinateArray, coordinateArrayOfArrays } from "../../../lib/GeoJSON";
-import { MeshBuilder } from "@babylonjs/core";
+import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
 import {LineTestReturnPacket} from "../../../lib/TileBuilding";
 
 class Game {

--- a/examples-local/wmts-local/src/index.ts
+++ b/examples-local/wmts-local/src/index.ts
@@ -15,8 +15,8 @@ import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { Button } from "@babylonjs/gui/2D/controls/button";
-import { TextBlock } from "@babylonjs/gui";
-import { Control } from "@babylonjs/gui";
+import { TextBlock } from "@babylonjs/gui/2D/controls/textBlock";
+import { Control } from "@babylonjs/gui/2D/controls/control";
 
 import "@babylonjs/core/Materials/standardMaterial"
 import "@babylonjs/inspector";

--- a/examples-npm/OpenStreetMap-Endless/src/index.ts
+++ b/examples-npm/OpenStreetMap-Endless/src/index.ts
@@ -15,10 +15,11 @@ import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
-import { ActionManager, KeyboardEventTypes, KeyboardInfo } from "@babylonjs/core";
+import { ActionManager } from "@babylonjs/core/Actions/actionManager";
+import { KeyboardEventTypes, KeyboardInfo } from "@babylonjs/core/Events/keyboardEvents";
 
-import { TextBlock } from "@babylonjs/gui";
-import { Control } from "@babylonjs/gui";
+import { TextBlock } from "@babylonjs/gui/2D/controls/textBlock";
+import { Control } from "@babylonjs/gui/2D/controls/control";
 
 import "@babylonjs/core/Materials/standardMaterial"
 import "@babylonjs/inspector";

--- a/examples-npm/OpenStreetMap-HelloWorld/src/index.ts
+++ b/examples-npm/OpenStreetMap-HelloWorld/src/index.ts
@@ -15,8 +15,8 @@ import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
 import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { Button } from "@babylonjs/gui/2D/controls/button";
-import { TextBlock } from "@babylonjs/gui";
-import { Control } from "@babylonjs/gui";
+import { TextBlock } from "@babylonjs/gui/2D/controls/textBlock";
+import { Control } from "@babylonjs/gui/2D/controls/control";
 
 import "@babylonjs/core/Materials/standardMaterial"
 import "@babylonjs/inspector";

--- a/examples-npm/OpenStreetMap-UserData-RealScale/src/index.ts
+++ b/examples-npm/OpenStreetMap-UserData-RealScale/src/index.ts
@@ -20,12 +20,12 @@ import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder"
 import { Mesh } from "@babylonjs/core/Meshes/mesh";
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
-import { ActionManager } from "@babylonjs/core";
-import { ExecuteCodeAction } from "@babylonjs/core";
+import { ActionManager } from "@babylonjs/core/Actions/actionManager";
+import { ExecuteCodeAction } from "@babylonjs/core/Actions/directActions";
 import { AdvancedDynamicTexture } from "@babylonjs/gui/2D/advancedDynamicTexture";
 import { Button } from "@babylonjs/gui/2D/controls/button";
-import { TextBlock } from "@babylonjs/gui";
-import { Control } from "@babylonjs/gui";
+import { TextBlock } from "@babylonjs/gui/2D/controls/textBlock";
+import { Control } from "@babylonjs/gui/2D/controls/control";
 
 import "@babylonjs/core/Materials/standardMaterial"
 import "@babylonjs/inspector";

--- a/examples-npm/mapbox-terrain/src/index.ts
+++ b/examples-npm/mapbox-terrain/src/index.ts
@@ -7,7 +7,7 @@
 
 import { Engine } from "@babylonjs/core/Engines/engine";
 import { Scene } from "@babylonjs/core/scene";
-import { EngineStore } from "@babylonjs/core";
+import { EngineStore } from "@babylonjs/core/Engines/engineStore";
 import { Vector2 } from "@babylonjs/core/Maths/math";
 import { Vector3 } from "@babylonjs/core/Maths/math";
 import { Color3 } from "@babylonjs/core/Maths/math";
@@ -19,8 +19,8 @@ import { DirectionalLight } from "@babylonjs/core/Lights/directionalLight";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder"
 import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
 import { Texture } from '@babylonjs/core/Materials/Textures/texture';
-import { TextBlock } from "@babylonjs/gui";
-import { Control } from "@babylonjs/gui";
+import { TextBlock } from "@babylonjs/gui/2D/controls/textBlock";
+import { Control } from "@babylonjs/gui/2D/controls/control";
 
 //import { AdvancedDynamicTexture } from "@babylonjs/gui/2D";
 import "@babylonjs/core/Materials/standardMaterial"

--- a/src/buildings/Buildings.ts
+++ b/src/buildings/Buildings.ts
@@ -8,7 +8,7 @@ import * as GeoJSON from './GeoJSON.js';
 import type Tile from "../core/Tile.js";
 import type TileSet from "../core/TileSet.js";
 import { EPSG_Type } from "../core/TileMath.js";
-import { Observable } from "@babylonjs/core";
+import { Observable } from "@babylonjs/core/Misc/observable.js";
 import { RetrievalLocation, RetrievalType } from "../shared/Retrieval.js";
 
 //import "@babylonjs/core/Materials/standardMaterial"

--- a/src/buildings/BuildingsWFS.ts
+++ b/src/buildings/BuildingsWFS.ts
@@ -1,7 +1,7 @@
 import { EPSG_Type } from "../core/TileMath.js";
 import { BuildingRequest} from "./Buildings.js";
 import { BuildingRequestType } from "./Buildings.js";
-import { Vector4 } from "@babylonjs/core";
+import { Vector4 } from "@babylonjs/core/Maths/math.js";
 import { RetrievalLocation, RetrievalType } from "../shared/Retrieval.js";
 
 import type Tile from "../core/Tile.js";

--- a/src/buildings/GeoJSON.ts
+++ b/src/buildings/GeoJSON.ts
@@ -2,7 +2,7 @@ import { Vector3 } from "@babylonjs/core/Maths/math.js";
 import { Vector2 } from "@babylonjs/core/Maths/math.js";
 import { Mesh } from "@babylonjs/core/Meshes/mesh.js";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder.js"
-import { Scene } from "@babylonjs/core";
+import { Scene } from "@babylonjs/core/scene.js";
 import { StandardMaterial } from '@babylonjs/core/Materials/standardMaterial.js';
 import Earcut from 'earcut';
 import type Buildings from "./Buildings.js";

--- a/src/core/Tile.ts
+++ b/src/core/Tile.ts
@@ -7,7 +7,7 @@ import type TileBuilding from "./TileBuilding.js";
 import { BoundingBox } from "@babylonjs/core/Culling/boundingBox.js";
 
 import type TileSet from "./TileSet.js";
-import { MeshBuilder } from "@babylonjs/core";
+import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder.js";
 
 //import "@babylonjs/core/Materials/standardMaterial"
 //import "@babylonjs/inspector";

--- a/src/core/TileMath.ts
+++ b/src/core/TileMath.ts
@@ -1,6 +1,6 @@
 import { Vector2, Vector4 } from "@babylonjs/core/Maths/math.js";
 import { Vector3 } from "@babylonjs/core/Maths/math.js";
-import { BoundingBox } from "@babylonjs/core";
+import { BoundingBox } from "@babylonjs/core/Culling/boundingBox.js";
 import Tile from './Tile';
 import TileSet from "./TileSet.js";
 

--- a/src/core/TileSet.ts
+++ b/src/core/TileSet.ts
@@ -1,12 +1,14 @@
 import { Scene } from "@babylonjs/core/scene.js";
-import { Engine, EngineStore, BoundingBox } from "@babylonjs/core";
+import { Engine } from "@babylonjs/core/Engines/engine.js";
+import { EngineStore } from "@babylonjs/core/Engines/engineStore.js";
+import { BoundingBox } from "@babylonjs/core/Culling/boundingBox.js";
 import { Vector2, Vector3, Color3 } from "@babylonjs/core/Maths/math.js";
 import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder.js"
 import { Mesh } from "@babylonjs/core/Meshes/mesh.js";
 import { StandardMaterial } from '@babylonjs/core/Materials/standardMaterial.js';
 import { Texture } from '@babylonjs/core/Materials/Textures/texture.js';
-import { AdvancedDynamicTexture } from "@babylonjs/gui";
-import { Observable } from "@babylonjs/core";
+import { AdvancedDynamicTexture } from "@babylonjs/gui/2D/advancedDynamicTexture.js";
+import { Observable } from "@babylonjs/core/Misc/observable.js";
 
 import Tile from './Tile.js';
 import TileMath, { EPSG_Type } from './TileMath.js';

--- a/src/terrain/TerrainMB.ts
+++ b/src/terrain/TerrainMB.ts
@@ -2,7 +2,8 @@ import { Scene } from "@babylonjs/core/scene.js";
 import { Vector2 } from "@babylonjs/core/Maths/math.js";
 import { Vector3 } from "@babylonjs/core/Maths/math.js";
 import { Texture } from '@babylonjs/core/Materials/Textures/texture.js';
-import { FloatArray, VertexBuffer } from "@babylonjs/core";
+import type { FloatArray } from "@babylonjs/core/types.js";
+import { VertexBuffer } from "@babylonjs/core/Buffers/buffer.js";
 import type Tile from '../core/Tile';
 import type TileSet from "../core/TileSet.js";
 


### PR DESCRIPTION
Fixes #37

## Summary

- replace package-source imports from the Babylon.js core and GUI barrels with focused modules
- update all local and npm examples to import only the Babylon.js modules they use
- keep action, keyboard, texture, material, and GUI imports on their dedicated entry points
- avoid changing the existing inspector imports used by the examples

## Validation

- `npm test -- --reporter=dot` (23 tests)
- `npm run build`
- `npm run build` for all 7 affected local examples
- `npm run build` for all 4 npm examples
- `git diff --check`

The example bundles still report the repository's existing size warnings because the demos intentionally include the Babylon.js inspector; the broad core/GUI imports are removed.
