### PR TITLE
Prepare version 1.1.44 npm publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,49 @@
+name: Publish package
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish babylonjs-mapping
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.14.0
+          registry-url: https://registry.npmjs.org
+
+      - name: Set up npm trusted publishing client
+        run: npm install --global npm@11.5.1
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build package
+        run: npm run build
+
+      - name: Match the release tag to package.json
+        if: ${{ github.event_name == 'release' }}
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          package_version="$(node --input-type=module --eval 'import { readFileSync } from "node:fs"; console.log(JSON.parse(readFileSync("package.json", "utf8")).version)')"
+          expected_tag="v${package_version}"
+          test "${RELEASE_TAG}" = "${expected_tag}"
+
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ https://people.duke.edu/~djzielin/babylonjs-mapping/Terrain/
 Tested with:
 Node 20.10.0 LTS
 
+## Releasing
+
+The package is published by `.github/workflows/publish-npm.yml` when a GitHub
+release is published with a matching `v<package version>` tag. The workflow
+runs the tests and build first, then publishes with npm provenance. Before
+creating the release, configure npm's trusted publisher for repository
+`djzielin/babylonjs-mapping` and workflow file `publish-npm.yml`.
+
 ## Building geometry options
 
 Call `createGeometry` and `updateRaster` before generating buildings. The library throws
@@ -112,4 +120,3 @@ Lead Developer, 2026–present
 Undergraduate, Computer Science / Electrical & Computer Engineering, Duke University
 
 <br clear="left">
-

--- a/examples-npm/OpenStreetMap-Endless/package.json
+++ b/examples-npm/OpenStreetMap-Endless/package.json
@@ -9,7 +9,7 @@
         "@babylonjs/inspector": "^6.37.1",
         "@babylonjs/materials": "^6.37.1",
         "@types/papaparse": "^5.3.14",
-        "babylonjs-mapping": "^1.1.31"
+        "babylonjs-mapping": "^1.1.44"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.18.0",

--- a/examples-npm/OpenStreetMap-HelloWorld/package.json
+++ b/examples-npm/OpenStreetMap-HelloWorld/package.json
@@ -8,7 +8,7 @@
         "@babylonjs/gui": "^6.37.1",
         "@babylonjs/inspector": "^6.37.1",
         "@babylonjs/materials": "^6.37.1",
-        "babylonjs-mapping": "^1.1.31"
+        "babylonjs-mapping": "^1.1.44"
     },
     "devDependencies": {
         "@types/earcut": "^2.1.4",

--- a/examples-npm/OpenStreetMap-UserData-RealScale/package.json
+++ b/examples-npm/OpenStreetMap-UserData-RealScale/package.json
@@ -9,7 +9,7 @@
         "@babylonjs/inspector": "^6.37.1",
         "@babylonjs/materials": "^6.37.1",
         "@types/papaparse": "^5.3.14",
-        "babylonjs-mapping": "^1.1.31",
+        "babylonjs-mapping": "^1.1.44",
         "cross-fetch": "^4.0.0",
         "papaparse": "^5.4.1"
     },

--- a/examples-npm/mapbox-terrain/package.json
+++ b/examples-npm/mapbox-terrain/package.json
@@ -8,7 +8,7 @@
         "@babylonjs/gui": "^6.37.1",
         "@babylonjs/inspector": "^6.37.1",
         "@babylonjs/materials": "^6.37.1",
-        "babylonjs-mapping": "^1.1.31",
+        "babylonjs-mapping": "^1.1.44",
         "cross-fetch": "^4.0.0"
     },
     "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "babylonjs-mapping",
-  "version": "1.1.43",
+  "version": "1.1.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "babylonjs-mapping",
-      "version": "1.1.43",
+      "version": "1.1.44",
       "license": "MIT",
       "dependencies": {
         "@babylonjs/core": "^6.49.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babylonjs-mapping",
-  "version": "1.1.43",
+  "version": "1.1.44",
   "author": "David Zielinski <djzielin@gmail.com>",
   "license": "MIT",
   "description": "module to help display map content from OpenStreetMaps, Mapbox, and AGOL natively in Babylon.js",
@@ -40,7 +40,11 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "build": "tsc --build tsconfig.npm.json",
-    "clean": "rimraf ./lib"
+    "clean": "rimraf ./lib",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #89
Closes #77

## Summary

- bump the package to `1.1.44`, the next publishable version after the existing `1.1.43` registry release
- add a GitHub Actions release workflow using npm trusted publishing and provenance
- run tests, build, and release-tag validation before publishing
- make all npm examples consume the new package version
- document the release and npm trusted-publisher setup

## Validation

- `npm test` (10 files, 41 tests)
- `npm run build`
- `npm pack --dry-run --json --ignore-scripts` contains `babylonjs-mapping@1.1.44`
- `npm@11.5.1 --version`
- `git diff --check`
