### PR TITLE
Rewrite README as a developer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,34 @@ npm test
 Report bugs and request features through
 [GitHub Issues](https://github.com/djzielin/babylonjs-mapping/issues).
 
+## Credits
+
+<img align="left" height="120" src="doc/vic_thumb.jpeg" alt="Vic Szabo">
+
+**[Vic Szabo](https://scholars.duke.edu/person/ves4)**<br>
+Principal Investigator<br>
+Research Professor of Art, Art History & Visual Studies, Duke University<br>
+Chair of Art, Art History & Visual Studies, Duke University
+
+<br clear="left">
+
+<img align="left" height="120" src="doc/dave_thumb.jpg" alt="David J. Zielinski">
+
+**[David J. Zielinski](https://people.duke.edu/~djzielin/)**<br>
+Senior AR/VR Technology Specialist, Duke University<br>
+Developer, 2022–2025<br>
+Project Manager, 2026–present
+
+<br clear="left">
+
+<img align="left" height="120" src="doc/thomas_thumb.jpeg" alt="Thomas Hines">
+
+**[Thomas Hines](https://www.linkedin.com/in/thethomashines/)**<br>
+Lead Developer, 2026–present<br>
+Undergraduate, Computer Science / Electrical & Computer Engineering, Duke University
+
+<br clear="left">
+
 ## License
 
 [MIT](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -1,300 +1,253 @@
 # babylonjs-mapping
-This project is to help do mapping inside BabylonJS. 
 
-Currently supported data sources include:
-* OpenStreetMaps and OpenStreetMaps Buildings
-![lots of gray buildings on top of map of roads](https://raw.githubusercontent.com/djzielin/babylonjs-mapping/main/doc/charlotte.jpg "Open Street Maps Demo")
-* Mapbox (satellite and terrain)
-![grand canyon with river at bottom](https://raw.githubusercontent.com/djzielin/babylonjs-mapping/main/doc/grand_canyon.jpg "Mapbox Terrain Demo")
-* GEBCO's global bathymetric grid as colour-shaded WMS imagery
-* Custom Buildings from GeoServer and ArcGIS Online (WFS)
+`babylonjs-mapping` renders tiled maps, terrain, and geographic feature data in
+[Babylon.js](https://www.babylonjs.com/) scenes. It provides a reusable tile
+grid, raster providers, building and vector-feature loaders, coordinate
+conversion helpers, and Mapbox terrain support.
 
-The "Hello World" of creating an OpenStreetMap tileset, along with extruded buildings is:
+The package is browser-oriented, published as ES modules, and includes
+TypeScript declarations.
 
+## Install
+
+```bash
+npm install babylonjs-mapping @babylonjs/core @babylonjs/gui @babylonjs/loaders
 ```
-    this.ourTS = new TileSet(this.scene,this.engine);
-    this.ourTS.setRasterProvider(new RasterOSM(this.ourTS)); //set basemap to pull from Open Street Maps
-    this.ourTS.createGeometry(new Vector2(4,4), 20, 2); //4x4 tile set, 20m width of each tile, and 2 divisions on each tile
-    this.ourTS.updateRaster(36.0014, -78.9382, 16); //lat, lon, zoom. takes us to Duke University in Durham.
 
-    this.ourOSM=new BuildingsOSM(this.ourTS); //lets pull building footprints from Open Street Map Buildings
-    this.ourOSM.accessToken=accessToken;      //now requires Auth token
-    this.ourOSM.generateBuildings();
-```
-Live Demos!  
-https://people.duke.edu/~djzielin/babylonjs-mapping/HelloWorld/  
-https://people.duke.edu/~djzielin/babylonjs-mapping/Terrain/  
+## Quick start
 
-Tested with:
-Node 20.10.0 LTS
-
-## Releasing
-
-The package is published by `.github/workflows/publish-npm.yml` when a GitHub
-release is published with a matching `v<package version>` tag. The workflow
-runs the tests and build first, then publishes with npm provenance. Before
-creating the release, configure npm's trusted publisher for repository
-`djzielin/babylonjs-mapping` and workflow file `publish-npm.yml`.
-
-## GitHub Pages demos
-
-The four npm examples are built and published to GitHub Pages from `main` by
-GitHub Actions. The workflow keeps the demos under separate paths and exposes
-an index page linking to each one. Add the repository's `OSMB_ACCESS_TOKEN` and
-`MAPBOX_ACCESS_TOKEN` Actions secrets if the live building and terrain data
-should be enabled; builds remain useful without those optional credentials.
-
-## Building geometry options
-
-Call `createGeometry` and `updateRaster` before generating buildings. The library throws
-a descriptive error when a geometry-dependent operation is called out of order.
-
-Line and point feature sizes are specified in Babylon world units, regardless of whether
-the source data uses EPSG:4326 or EPSG:3857:
+Create the tile geometry before selecting its geographic location. The tile
+width and feature dimensions use Babylon world units.
 
 ```ts
-streets.lineWidth = 0.25;
-points.pointDiameter = 0.5;
+import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera.js";
+import { Engine } from "@babylonjs/core/Engines/engine.js";
+import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight.js";
+import { Vector2, Vector3 } from "@babylonjs/core/Maths/math.vector.js";
+import { Scene } from "@babylonjs/core/scene.js";
+import { RasterOSM, TileSet } from "babylonjs-mapping";
+
+const canvas = document.querySelector<HTMLCanvasElement>("#renderCanvas")!;
+const engine = new Engine(canvas, true);
+const scene = new Scene(engine);
+
+const camera = new ArcRotateCamera(
+    "camera",
+    -Math.PI / 2,
+    Math.PI / 3,
+    100,
+    Vector3.Zero(),
+    scene,
+);
+camera.attachControl(canvas, true);
+
+new HemisphericLight("light", new Vector3(0, 1, 0), scene);
+
+const tiles = new TileSet(scene, engine);
+tiles.setRasterProvider(new RasterOSM(tiles));
+tiles.createGeometry(new Vector2(4, 4), 20, 2);
+tiles.updateRaster(36.0014, -78.9382, 16);
+
+engine.runRenderLoop(() => scene.render());
+window.addEventListener("resize", () => engine.resize());
 ```
 
-OSM Buildings roof metadata is applied automatically. `gabled`, `hipped`,
-`pyramidal`/`pyramid`, and `skillion` roof shapes honor `roofHeight`,
-`roofLevels`, and `roofDirection` (as well as the equivalent raw
-`roof:*` property names). Complex footprints that cannot be roofed without
-changing their topology keep the existing full-height flat extrusion.
+`createGeometry(tileCount, tileWidth, meshPrecision)` creates the reusable
+mesh grid. `updateRaster(latitude, longitude, zoom)` centers that grid on a
+standard slippy-map coordinate and requests imagery from the configured raster
+provider.
 
-## Mapbox landmark buildings
+## Providers
 
-Mapbox's detailed landmark models can be loaded after the tileset raster
-coordinates are initialized. The provider automatically requests and places
-the fixed zoom-14 model tiles that overlap the current tileset:
+| Data | Provider | Credentials or configuration |
+| --- | --- | --- |
+| OpenStreetMap raster imagery | `RasterOSM` | None |
+| Mapbox raster imagery | `RasterMB` | Mapbox access token |
+| GEBCO bathymetry imagery | `RasterGEBCO` | None |
+| WMTS imagery | `RasterWMTS` | WMTS endpoint and layer |
+| OSM Buildings geometry | `BuildingsOSM` | OSM Buildings/OneGeo access token |
+| Mapbox landmark models | `BuildingsMB` | Mapbox access token |
+| Mapbox or custom MVT features | `BuildingsVectorTile` | Token for Mapbox; URL and source layers for custom services |
+| Overture Maps buildings | `BuildingsOverture` | PMTiles source; defaults to the latest public release |
+| GeoServer, WFS, or ArcGIS features | `BuildingsWFS` | Service URL, layer, and source CRS |
+| Mapbox terrain | `TerrainMB` through `TileSet` | Mapbox access token |
+
+External services retain their own usage terms, attribution requirements,
+rate limits, and CORS policies. Keep API tokens out of source control and
+inject them through your application's normal secret/configuration mechanism.
+
+## Add buildings
+
+Initialize raster coordinates before requesting buildings. Building requests
+use the current tile coordinates and are processed while the Babylon scene is
+rendering.
 
 ```ts
-const landmarks = new BuildingsMB(tileSet);
-landmarks.accessToken = mapboxAccessToken;
-await landmarks.generateBuildings();
+import { BuildingsOSM } from "babylonjs-mapping";
+
+const buildings = new BuildingsOSM(tiles);
+buildings.accessToken = osmbAccessToken;
+buildings.generateBuildings();
 ```
 
-Call `generateBuildings()` again after `updateRaster()` to reuse overlapping
-model tiles and dispose models that moved out of view. Call `dispose()` when
-the provider is no longer needed.
-
-## GEBCO bathymetry
-
-`RasterGEBCO` streams colour-shaded tiles from GEBCO's public Web Map Service.
-The default `GEBCO_LATEST_2` layer shows elevation and bathymetry using GEBCO's
-latest grid; `GEBCO_LATEST` provides shaded relief and `GEBCO_LATEST_3` shows
-measured-data coverage. The service's `LATEST` layers can change when GEBCO
-publishes a new grid, so applications should include the current attribution
-and link to the [GEBCO WMS documentation](https://www.gebco.net/data-products/gebco-web-services/web-map-service).
+Feature widths and diameters are Babylon world units, even when source data is
+EPSG:4326 or EPSG:3857:
 
 ```ts
-const bathymetry = new RasterGEBCO(tileSet);
-tileSet.setRasterProvider(bathymetry);
-tileSet.createGeometry(new Vector2(4, 3), 100, 2);
-tileSet.updateRaster(11.35, 142.2, 6); // Mariana Trench region
+buildings.lineWidth = 0.25;
+buildings.pointDiameter = 0.5;
 ```
 
-The provider uses GEBCO's WMS imagery, which is intended for visualization and
-not navigation or safety-at-sea purposes. The full downloadable grids are
-available from [GEBCO's data download service](https://download.gebco.net/).
-
-## Endless tile lifecycle
-
-When `moveAllTiles()` recycles a tile, `onTilePositionUpdatedObservable`
-provides the tile plus snapshots of its previous and new coordinates. This lets
-an endless-world application remove user-owned objects for the old tile and
-create replacements for the new one:
+For ArcGIS-hosted data, use the matching setup helper before loading:
 
 ```ts
-tileSet.onTilePositionUpdatedObservable.add(({ tile, previousTileCoords, tileCoords }) => {
-    removeItemsForTile(previousTileCoords);
-    addItemsForTile(tileCoords, tile);
+import { BuildingsWFS, EPSG_Type } from "babylonjs-mapping";
+
+const features = new BuildingsWFS(
+    "buildings",
+    "https://services.arcgis.com/example/FeatureServer",
+    "0",
+    EPSG_Type.EPSG_4326,
+    tiles,
+);
+
+features.setupAGOLFeatureService();
+features.generateBuildings();
+```
+
+`setupAGOL()` supports an ArcGIS WFS endpoint, while `setupGeoServer()`
+configures GeoServer-style requests. Both WFS and ArcGIS Feature Service
+loading handle paginated results.
+
+## Add Mapbox terrain
+
+Use a sufficiently high mesh precision when terrain detail matters. Terrain
+generation is asynchronous.
+
+```ts
+import { RasterMB } from "babylonjs-mapping";
+
+const terrainTiles = new TileSet(scene, engine);
+const raster = new RasterMB(terrainTiles);
+raster.accessToken = mapboxAccessToken;
+terrainTiles.setRasterProvider(raster);
+
+terrainTiles.createGeometry(new Vector2(4, 4), 50, 32);
+terrainTiles.ourTerrainMB.accessToken = mapboxAccessToken;
+terrainTiles.updateRaster(36.1005, -112.1127, 14);
+
+await terrainTiles.generateTerrain(1);
+terrainTiles.setupTerrainLOD([16, 4, 1, 0], [64, 128, 256, 512]);
+```
+
+The final terrain LOD precision may be `0` to hide distant tiles. LOD
+distances and terrain dimensions use Babylon world units.
+
+## Moving and endless maps
+
+`moveAllTiles()` recycles tiles that leave the grid. Subscribe to
+`onTilePositionUpdatedObservable` when application-owned markers or meshes
+must move with that lifecycle:
+
+```ts
+tiles.onTilePositionUpdatedObservable.add(({ tile, previousTileCoords, tileCoords }) => {
+    removeObjectsForTile(previousTileCoords);
+    addObjectsForTile(tileCoords, tile);
 });
 ```
 
-The notification is sent after the tile's raster request and optional building
-request have been submitted.
+Pass `true` as the fifth `moveAllTiles()` argument to reload terrain when a
+tile is recycled.
 
-## Mapbox vector roads
+## Performance controls
 
-`BuildingsVectorTile` loads Mapbox Streets v8 vector tiles and feeds selected
-source layers into the existing GeoJSON geometry pipeline. Its default layer
-is `road`; line features are converted to low-profile extrusions, and their
-source properties remain available on the generated mesh metadata:
-
-```ts
-const roads = new BuildingsVectorTile(tileSet);
-roads.accessToken = mapboxAccessToken;
-roads.lineWidth = 0.25;
-roads.sourceLayers = ["road"];
-roads.generateBuildings();
-```
-
-The provider also accepts a custom `{z}/{x}/{y}` vector-tile URL and a list of
-source layers, which can be used with traffic or other compatible MVT data:
-
-```ts
-const traffic = new BuildingsVectorTile(
-    tileSet,
-    "https://tiles.example/{z}/{x}/{y}.pbf",
-    ["traffic"],
-);
-traffic.generateBuildings();
-```
-
-## ArcGIS Online WFS pagination
-
-`BuildingsWFS.setupAGOL()` enables WFS 2.0 result paging automatically. Each
-request is limited to 3,000 features and subsequent requests use a zero-based
-`startIndex`, so large hosted WFS layers can be loaded without silently losing
-features. Geometry creation and optional merging continue after the final page.
-
-```ts
-const buildings = new BuildingsWFS(
-    "buildings",
-    "https://your-org.arcgis.com/.../WFSServer?",
-    "your-layer:your-feature-type",
-    EPSG_Type.EPSG_4326,
-    tileSet,
-);
-
-buildings.setupAGOL(); // enables count=3000/startIndex pagination
-buildings.generateBuildings();
-```
-
-`maxFeaturesPerRequest` defaults to `3000` and can be lowered when testing or
-when a service advertises a smaller page limit.
-
-For ArcGIS Feature Services, the REST query API can be used directly instead of
-creating a WFS share. The provider sends a GeoJSON query constrained to each
-map tile and uses `resultOffset`/`resultRecordCount` paging:
-
-```ts
-const buildings = new BuildingsWFS(
-    "buildings",
-    "https://services.arcgis.com/.../FeatureServer",
-    "0",
-    EPSG_Type.EPSG_4326,
-    tileSet,
-);
-
-buildings.setupAGOLFeatureService();
-buildings.generateBuildings();
-```
-
-You can also pass a complete `/query` URL or preserve a service token in the
-URL query string.
-
-## Building LOD
-
-Building billboards are opt-in. Configure them before generating buildings:
-
-```ts
-this.ourOSM.buildingLOD = {
-    enabled: true,
-    distance: 100, // Babylon world units
-};
-this.ourOSM.generateBuildings();
-```
-
-At the configured distance, Babylon.js swaps each detailed building for a double-sided rectangle sized from its world-space bounds and billboarded around the vertical axis. Set `billboardMode` to `Mesh.BILLBOARDMODE_ALL` when full camera-facing rotation is preferred. Per-building LOD requires individual meshes, so `buildingLOD.enabled` keeps buildings separate even when `doMerge` is also true.
-
-## Performance controls and measurements
-
-Optimization choices are explicit on both `Buildings` and `TileSet` providers. Building
-world matrices remain live by default because the endless example moves its tile parents;
-static scenes can freeze them after generation. Building meshes remain pickable by default
-for compatibility, while the shared building material is frozen by default. Picking,
-collisions, and distance-based request prioritization can be changed independently:
+Static scenes can freeze matrices and disable interactions they do not use.
+Keep tile world matrices unfrozen when tiles move.
 
 ```ts
 buildings.setOptimizationOptions({
-    freezeWorldMatrices: true,       // static tiles only
-    freezeMaterials: false,          // allow selection/highlight material edits
+    freezeWorldMatrices: true,
     disablePicking: true,
     disableCollisions: true,
     prioritizeRequestsByDistance: true,
 });
 
-tileSet.setOptimizationOptions({
+tiles.setOptimizationOptions({
     freezeRasterMaterials: true,
-    freezeTileWorldMatrices: false,  // keep false when moveAllTiles() is used
+    freezeTileWorldMatrices: false,
     disableTilePicking: false,
     disableTileCollisions: true,
 });
 ```
 
-Distance prioritization keeps one network request in flight, processes the closest
-available tile first, and never merges a tile while its building-creation requests are
-still pending. This is useful for endless scenes where nearby content should appear first.
-
-For a before/after comparison, enable frame sampling and inspect the cumulative geometry
-and LOD counters:
+Building billboard LOD is opt-in:
 
 ```ts
-buildings.setPerformanceMonitoringEnabled(true);
-// ...render a representative camera path...
-console.log(buildings.getPerformanceStats());
+buildings.buildingLOD = {
+    enabled: true,
+    distance: 100,
+};
 ```
 
-The returned data includes detailed/billboard vertex counts, estimated vertex reduction,
-LOD selections, queue depth, and average/min/max frame times. Call
-`resetPerformanceStats()` between test runs.
+Use `setPerformanceMonitoringEnabled(true)`, `getPerformanceStats()`, and
+`resetPerformanceStats()` to measure queue depth, geometry reduction, LOD
+selection, and sampled frame times.
 
-## Endless terrain recycling
+## Local caching
 
-`moveAllTiles` can reload Mapbox terrain for tiles that are recycled at the edge
-of an endless tileset. Pass `true` as the optional fifth argument after terrain
-has been configured:
-
-```ts
-await tileSet.generateTerrain(1);
-
-scene.onBeforeRenderObservable.add(() => {
-    tileSet.moveAllTiles(dx, dz, 2, buildings, true);
-});
-```
-
-Terrain seam repair is re-applied for every loaded cardinal and diagonal
-neighbor whenever a tile finishes loading, so recycled DEM data does not retain
-stale seam state.
-
-## Local cache paths
-
-WMTS raster providers and all-data WFS building providers use `map_cache/` by
-default when `RetrievalLocation.Local` is selected. Set `localPathPrefix` to
-serve the cache below another relative directory or an absolute URL path:
+Providers that support `RetrievalLocation.Local` read from `map_cache/` by
+default. Change `localPathPrefix` when the cache is hosted elsewhere:
 
 ```ts
 raster.localPathPrefix = "assets/map_cache/";
 buildings.localPathPrefix = "assets/map_cache/";
 ```
 
-## Credits
+## Examples
 
-<img align="left" height="120" src="doc/vic_thumb.jpeg" alt="Vic Szabo">
+Runnable applications are under [`examples-npm`](examples-npm):
 
-**[Vic Szabo](https://scholars.duke.edu/person/ves4)**  
-Principal Investigator  
-Research Professor of Art, Art History & Visual Studies, Duke University  
-Chair of Art, Art History & Visual Studies, Duke University
+- [OpenStreetMap Hello World](examples-npm/OpenStreetMap-HelloWorld)
+- [Endless OpenStreetMap](examples-npm/OpenStreetMap-Endless)
+- [OpenStreetMap user data at real scale](examples-npm/OpenStreetMap-UserData-RealScale)
+- [Mapbox terrain](examples-npm/mapbox-terrain)
+- [GEBCO bathymetry](examples-npm/gebco-bathymetry)
 
-<br clear="left">
+Each example has its own README and npm scripts. A typical example can be run
+with:
 
-<img align="left" height="120" src="doc/dave_thumb.jpg" alt="David J. Zielinski">
+```bash
+cd examples-npm/OpenStreetMap-HelloWorld
+npm install
+npm start
+```
 
-**[David J. Zielinski](https://people.duke.edu/~djzielin/)**  
-Senior AR/VR Technology Specialist, Duke University  
-Developer, 2022–2025  
-Project Manager, 2026–present
+Examples that use commercial services expect their access-token text files as
+documented in the example directory.
 
-<br clear="left">
+## API and compatibility notes
 
-<img align="left" height="120" src="doc/thomas_thumb.jpeg" alt="Thomas Hines">
+- Public classes and types are exported from `babylonjs-mapping`.
+- Compatibility subpath exports under `babylonjs-mapping/lib/*` remain
+  available for existing consumers.
+- The package uses ES modules. Include the `.js` suffix when importing Babylon
+  modules directly, as shown above.
+- Geometry-dependent calls throw descriptive errors when geometry or raster
+  coordinates have not been initialized.
+- Dispose application-owned providers, observers, and Babylon resources when
+  their scene is torn down.
 
-**[Thomas Hines](https://www.linkedin.com/in/thethomashines/)**  
-Lead Developer, 2026–present  
-Undergraduate, Computer Science / Electrical & Computer Engineering, Duke University
+## Development
 
-<br clear="left">
+```bash
+npm ci
+npm run build
+npm test
+```
+
+Report bugs and request features through
+[GitHub Issues](https://github.com/djzielin/babylonjs-mapping/issues).
+
+## License
+
+[MIT](LICENSE.md)


### PR DESCRIPTION
## Summary

- replace project-history and implementation-detail sections with a consumer-focused library overview
- add installation and a complete Babylon.js quick start
- document supported raster, building, vector, and terrain providers in one configuration table
- add practical workflows for buildings, ArcGIS, Mapbox terrain, endless maps, performance controls, and local caching
- link every maintained npm example and clarify ESM/API compatibility expectations
- retain the project credits and concise contributor build/test commands

## Removed

- release workflow and GitHub Actions implementation details
- stale Duke-hosted demo links
- screenshots and long feature-by-feature implementation notes

## Validation

- `npm run build`
- verified every repository-relative README link
- `git diff --check`