### PR TITLE
Add a Hello World immersive WebXR demo

### DIFF
--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -14,6 +14,7 @@
     <h1>babylonjs-mapping demos</h1>
     <p>Live Babylon.js mapping examples built from this repository.</p>
     <a href="OpenStreetMap-HelloWorld/">OpenStreetMap Hello World</a>
+    <a href="hello-world-webxr/">Hello World WebXR (Quest / VR)</a>
     <a href="OpenStreetMap-Endless/">OpenStreetMap Endless</a>
     <a href="OpenStreetMap-UserData-RealScale/">OpenStreetMap User Data</a>
     <a href="mapbox-terrain/">Mapbox Terrain</a>

--- a/.github/workflows/deploy-demos.yml
+++ b/.github/workflows/deploy-demos.yml
@@ -49,6 +49,7 @@ jobs:
           demos=(
             OpenStreetMap-Endless
             OpenStreetMap-HelloWorld
+            hello-world-webxr
             OpenStreetMap-UserData-RealScale
             mapbox-terrain
             gebco-bathymetry

--- a/examples-npm/hello-world-webxr/index.html
+++ b/examples-npm/hello-world-webxr/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hello World · WebXR campus map</title>
+  <style>
+    html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; font: 16px/1.5 system-ui, sans-serif; background: #15232b; color: white; }
+    #renderCanvas { width: 100%; height: 100%; touch-action: none; outline: none; }
+    #help { position: absolute; top: 1rem; left: 1rem; max-width: min(30rem, calc(100% - 4rem)); padding: 1rem; border-radius: .7rem; background: #15232be8; }
+    h1 { font-size: 1.2rem; margin: 0 0 .5rem; }
+    p { margin: .4rem 0; }
+    button { font: inherit; padding: .5rem 1rem; cursor: pointer; }
+    a { color: #a4e7ff; }
+  </style>
+</head>
+<body>
+  <canvas id="renderCanvas" aria-label="Interactive miniature map of Duke University" tabindex="0"></canvas>
+  <section id="help">
+    <h1>Hello World · WebXR</h1>
+    <p>A miniature Duke campus at your feet. Drag to look; arrow keys to move.</p>
+    <p>In VR: push a thumbstick forward to aim a teleport, release to travel. Move it sideways to snap turn. Use your headset menu to exit.</p>
+    <p id="xr-status" role="status">Checking immersive VR support…</p>
+    <button id="enter-vr" disabled>Enter VR</button>
+    <p id="building-status" role="status">Loading buildings…</p>
+    <small>Map: <a href="https://www.openstreetmap.org/copyright">© OpenStreetMap contributors</a> · Buildings: <a href="https://docs.overturemaps.org/attribution/">Overture Maps</a></small>
+  </section>
+</body>
+</html>

--- a/examples-npm/hello-world-webxr/package.json
+++ b/examples-npm/hello-world-webxr/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "hello-world-webxr",
+  "version": "1.0.0",
+  "description": "Explore a miniature Duke campus map in immersive WebXR or on desktop",
+  "main": "index.ts",
+  "dependencies": {
+    "@babylonjs/core": "^6.37.1",
+    "@babylonjs/gui": "^6.37.1",
+    "babylonjs-mapping": "^1.1.44",
+    "@babylonjs/loaders": "^6.49.0"
+  },
+  "devDependencies": {
+    "@types/earcut": "^2.1.4",
+    "clean-webpack-plugin": "^4.0.0",
+    "html-webpack-plugin": "^5.6.0",
+    "source-map-loader": "^4.0.2",
+    "ts-loader": "^9",
+    "typescript": "^5.3.3",
+    "webpack": "^5.89.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1",
+    "webpack-merge": "^5.10.0",
+    "iwer": "2.3.0",
+    "playwright": "1.61.1"
+  },
+  "scripts": {
+    "start": "npx webpack-dev-server --config webpack.config-dev.js",
+    "build": "npx webpack --config webpack.config-prod.js",
+    "test:xr": "node tests/null-headset.mjs"
+  },
+  "author": "David J. Zielinski. original template by Evan Suma Rosenberg <suma@umn.edu> and Blair MacIntyre <blair@cc.gatech.edu>",
+  "license": "CC BY-NC-SA 4.0"
+}

--- a/examples-npm/hello-world-webxr/src/index.ts
+++ b/examples-npm/hello-world-webxr/src/index.ts
@@ -1,0 +1,117 @@
+import { Engine } from "@babylonjs/core/Engines/engine";
+import { Scene } from "@babylonjs/core/scene";
+import { Vector2, Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { Color3, Color4 } from "@babylonjs/core/Maths/math.color";
+import { UniversalCamera } from "@babylonjs/core/Cameras/universalCamera";
+import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
+import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { WebXRDefaultExperience } from "@babylonjs/core/XR/webXRDefaultExperience";
+import { WebXRState } from "@babylonjs/core/XR/webXRTypes";
+import { AdvancedDynamicTexture } from "@babylonjs/gui/2D/advancedDynamicTexture";
+import { TextBlock } from "@babylonjs/gui/2D/controls/textBlock";
+import "@babylonjs/core/Helpers/sceneHelpers";
+import "@babylonjs/core/XR/motionController/webXROculusTouchMotionController";
+import { BuildingsOverture, resolveLatestOvertureBuildingsURL, RasterOSM, TileSet } from "babylonjs-mapping";
+
+const canvas = document.getElementById("renderCanvas") as unknown as HTMLCanvasElement;
+const help = document.getElementById("help")!;
+const status = document.getElementById("xr-status")!;
+const buildingStatus = document.getElementById("building-status")!;
+const enterButton = document.getElementById("enter-vr") as HTMLButtonElement;
+const engine = new Engine(canvas, true);
+export const scene = new Scene(engine);
+scene.clearColor = new Color4(0.13, 0.22, 0.28, 1);
+const camera = new UniversalCamera("desktop", new Vector3(0, 1.6, -3), scene);
+camera.setTarget(Vector3.Zero());
+camera.minZ = 0.02;
+camera.speed = 0.03;
+camera.attachControl(canvas, true);
+new HemisphericLight("sky", new Vector3(0, 1, 0), scene);
+
+// One scene unit remains one physical metre in XR; the map is a 4 m miniature.
+export const map = new TileSet(scene, engine);
+export let xrExperience: WebXRDefaultExperience | undefined;
+map.setRasterProvider(new RasterOSM(map));
+map.createGeometry(new Vector2(4, 4), 1, 1);
+map.updateRaster(36.0014, -78.9382, 16);
+const floor = MeshBuilder.CreateGround("teleport-floor", { width: 10, height: 10 }, scene);
+floor.position.y = -0.01;
+const floorMaterial = new StandardMaterial("floor-material", scene);
+floorMaterial.diffuseColor = new Color3(0.24, 0.32, 0.35);
+floor.material = floorMaterial;
+
+// Screen overlays do not appear in immersive VR, so keep instructions and credits in the scene.
+const sign = MeshBuilder.CreatePlane("campus-sign", { width: 3, height: 0.9 }, scene);
+sign.position.set(0, 1.5, 2.8);
+sign.isPickable = false;
+const signTexture = AdvancedDynamicTexture.CreateForMesh(sign, 1536, 460);
+signTexture.background = "#15232b";
+const signText = new TextBlock("instructions", "DUKE CAMPUS · HELLO WORLD\nThumbstick: teleport / snap turn · Headset menu: exit\nMap © OpenStreetMap contributors · Buildings © Overture Maps");
+signText.color = "white";
+signText.fontSize = 40;
+signTexture.addControl(signText);
+
+engine.runRenderLoop(() => scene.render());
+window.addEventListener("resize", () => engine.resize());
+
+async function loadBuildings(): Promise<void> {
+    try {
+        const buildings = new BuildingsOverture(map, await resolveLatestOvertureBuildingsURL());
+        buildings.doMerge = true;
+        buildings.exaggeration = 1;
+        buildings.onCaughtUpObservable.addOnce(() => {
+            const count = map.ourTiles.reduce((total, tile) => total + tile.buildings.length, 0);
+            buildingStatus.textContent = count ? "Buildings ready." : "No buildings loaded. Reload to retry.";
+        });
+        buildings.generateBuildings();
+    } catch (error) {
+        buildingStatus.textContent = "Buildings unavailable. Reload to retry; the map still works.";
+        console.error("Unable to load buildings", error);
+    }
+}
+
+async function setupXR(): Promise<void> {
+    if (!window.isSecureContext) {
+        status.textContent = "VR requires HTTPS. Open the HTTPS demo in Quest Browser.";
+        return;
+    }
+    if (!navigator.xr || !await navigator.xr.isSessionSupported("immersive-vr")) {
+        status.textContent = "VR unavailable here. Open in Quest Browser, or explore on desktop.";
+        return;
+    }
+    const xr = await WebXRDefaultExperience.CreateAsync(scene, {
+        disableDefaultUI: true,
+        floorMeshes: [floor, ...map.ourTiles.map(tile => tile.mesh)],
+        disableHandTracking: true,
+        disableNearInteraction: true,
+        // Bundled Touch input mapping supports Quest thumbsticks without remote profile requests.
+        inputOptions: { forceInputProfile: "oculus-touch", disableOnlineControllerRepository: true, doNotLoadControllerMeshes: true },
+    });
+    xrExperience = xr;
+    xr.baseExperience.camera.minZ = 0.02;
+    xr.baseExperience.onStateChangedObservable.add(state => {
+        help.hidden = state === WebXRState.IN_XR;
+        enterButton.disabled = state !== WebXRState.NOT_IN_XR;
+        if (state === WebXRState.NOT_IN_XR) status.textContent = "VR ready. Select Enter VR to return.";
+    });
+    enterButton.disabled = false;
+    status.textContent = "VR ready. Select Enter VR to explore the campus.";
+    enterButton.addEventListener("click", async () => {
+        enterButton.disabled = true;
+        try {
+            await xr.baseExperience.enterXRAsync("immersive-vr", "local-floor", xr.renderTarget);
+        } catch (error) {
+            help.hidden = false;
+            enterButton.disabled = false;
+            status.textContent = "Could not enter VR. Check headset permissions and try again.";
+            console.error("Unable to enter VR", error);
+        }
+    });
+}
+
+void loadBuildings();
+void setupXR().catch(error => {
+    status.textContent = "VR setup failed. Reload to retry, or explore on desktop.";
+    console.error("Unable to initialize WebXR", error);
+});

--- a/examples-npm/hello-world-webxr/tests/null-headset.mjs
+++ b/examples-npm/hello-world-webxr/tests/null-headset.mjs
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { dirname, resolve, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+// npm run build && npx playwright install chromium && npm run test:xr
+// A null headset: Meta's IWER Quest 3 profile, with no physical XR hardware.
+const require = createRequire(import.meta.url);
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const runtime = resolve(dirname(require.resolve('iwer')), '../build/iwer.min.js');
+const server = createServer(async (request, response) => {
+    try {
+        const pathname = new URL(request.url, 'http://localhost').pathname;
+        const file = resolve(root, 'dist', '.' + (pathname === '/' ? '/index.html' : pathname));
+        if (!file.startsWith(resolve(root, 'dist') + '/')) throw new Error('Invalid path');
+        response.setHeader('Content-Type', extname(file) === '.js' ? 'text/javascript' : 'text/html');
+        response.end(await readFile(file));
+    } catch { response.writeHead(404).end(); }
+});
+await new Promise(done => server.listen(0, '127.0.0.1', done));
+const url = `http://127.0.0.1:${server.address().port}`;
+let browser;
+try {
+    browser = await chromium.launch({ headless: true, args: ['--no-sandbox', '--enable-unsafe-swiftshader'] });
+    const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+    page.setDefaultTimeout(30000);
+    const errors = [];
+    page.on('pageerror', error => errors.push(error.message));
+    await page.addInitScript({ path: runtime });
+    await page.addInitScript(() => {
+        window.nullHeadset = new IWER.XRDevice(IWER.metaQuest3, { stereoEnabled: true });
+        nullHeadset.installRuntime({ forceInstall: true });
+        nullHeadset.position.set(0, 1.6, 0);
+        const requestSession = navigator.xr.requestSession.bind(navigator.xr);
+        navigator.xr.requestSession = async (...args) => {
+            if (window.rejectNextSession) {
+                window.rejectNextSession = false;
+                throw new DOMException('Test permission denial', 'NotAllowedError');
+            }
+            const session = await requestSession(...args);
+            window.testSession = session;
+            window.testFrames = 0;
+            const space = await session.requestReferenceSpace('local-floor');
+            const frame = (_, xrFrame) => {
+                window.testFrames++;
+                window.testEyes = xrFrame.getViewerPose(space)?.views.map(view => view.eye);
+                session.requestAnimationFrame(frame);
+            };
+            session.requestAnimationFrame(frame);
+            return session;
+        };
+    });
+    page.on('console', message => { if (message.type() === 'error') console.error(message.text()); });
+    await page.goto(url);
+    console.log('Loaded demo');
+    await page.waitForFunction(() => !document.querySelector('#enter-vr').disabled);
+    await page.evaluate(() => window.rejectNextSession = true);
+    await page.click('#enter-vr');
+    await page.waitForFunction(() => document.querySelector('#xr-status').textContent.includes('Could not enter VR'));
+    assert.equal(await page.isDisabled('#enter-vr'), false);
+    await page.click('#enter-vr');
+    console.log('Requested immersive session');
+    await page.waitForFunction(() => window.testFrames > 10 && helloWorldWebXR.xrExperience.input.controllers.length === 2);
+    assert.deepEqual(await page.evaluate(() => testEyes), ['left', 'right']);
+    await page.waitForFunction(() => helloWorldWebXR.scene.activeCamera.rigCameras.length === 2);
+    assert.equal(await page.isHidden('#help'), true);
+    console.log('Stereo and controllers ready');
+    const before = await page.evaluate(() => helloWorldWebXR.scene.activeCamera.position.asArray());
+    await page.evaluate(() => nullHeadset.position.x += 0.25);
+    await page.waitForFunction(x => Math.abs(helloWorldWebXR.scene.activeCamera.position.x - x - 0.25) < 0.01, before[0]);
+    await page.waitForFunction(() => helloWorldWebXR.xrExperience.input.controllers.every(c => c.motionController));
+    console.log('Head tracking passed');
+    const rotation = await page.evaluate(() => helloWorldWebXR.scene.activeCamera.rotationQuaternion.asArray());
+    await page.evaluate(() => nullHeadset.controllers.right.updateAxes('thumbstick', 1, 0));
+    await page.waitForFunction(previous => helloWorldWebXR.scene.activeCamera.rotationQuaternion.asArray().some((v, i) => Math.abs(v - previous[i]) > 0.1), rotation);
+    await page.evaluate(() => nullHeadset.controllers.right.updateAxes('thumbstick', 0, 0));
+    await page.waitForFunction(() => helloWorldWebXR.xrExperience.input.controllers.find(c => c.inputSource.handedness === 'right').motionController.getComponentOfType('thumbstick').axes.x === 0);
+    console.log('Snap turn passed');
+    // Return to the initial heading before aiming the right controller at the map.
+    await page.evaluate(() => {
+        helloWorldWebXR.scene.activeCamera.rotationQuaternion.set(0, 0, 0, 1);
+        nullHeadset.controllers.right.position.set(0.25, 1.2, -0.3);
+        nullHeadset.controllers.right.quaternion.set(-Math.sin(Math.PI / 8), 0, 0, Math.cos(Math.PI / 8));
+        nullHeadset.controllers.right.updateAxes('thumbstick', 0, -1);
+    });
+    await page.waitForFunction(() => helloWorldWebXR.xrExperience.teleportation.teleportationTargetMesh.isVisible).catch(async error => {
+        console.log(await page.evaluate(() => {
+            const xr = helloWorldWebXR.xrExperience;
+            return {camera: xr.baseExperience.camera.position.asArray(), controllers: xr.input.controllers.map(c => ({id:c.uniqueId, position:c.pointer.position.asArray(), rotation:c.pointer.rotationQuaternion.asArray(), axes:c.motionController.getComponentOfType('thumbstick').axes})), teleport: Object.keys(xr.teleportation), target:xr.teleportation.teleportationTargetMesh.position.asArray()};
+        }));
+        await page.screenshot({path: resolve(root, 'test-results/teleport-failure.png')});
+        throw error;
+    });
+    console.log('Teleport target visible');
+    const teleportStart = await page.evaluate(() => helloWorldWebXR.scene.activeCamera.position.asArray());
+    await page.evaluate(() => nullHeadset.controllers.right.updateAxes('thumbstick', 0, 0));
+    await page.waitForFunction(start => Math.hypot(helloWorldWebXR.scene.activeCamera.position.x - start[0], helloWorldWebXR.scene.activeCamera.position.z - start[2]) > 0.2, teleportStart);
+    console.log('Teleport movement passed');
+    await page.waitForFunction(() => document.querySelector('#building-status').textContent === 'Buildings ready.', null, { timeout: 90000 });
+    console.log('Buildings ready');
+    const buildings = await page.evaluate(() => helloWorldWebXR.map.ourTiles.reduce((n, tile) => n + tile.buildings.length, 0));
+    assert.ok(buildings > 0);
+    await page.evaluate(() => nullHeadset.quaternion.set(-Math.sin(Math.PI / 12), 0, 0, Math.cos(Math.PI / 12)));
+    await page.waitForFunction(() => Math.abs(helloWorldWebXR.scene.activeCamera.rotationQuaternion.x) > 0.2);
+    await page.screenshot({ path: resolve(root, 'test-results/null-headset-stereo.png') });
+    await page.evaluate(() => testSession.end());
+    await page.waitForFunction(() => helloWorldWebXR.scene.activeCamera.name === 'desktop' && !document.querySelector('#help').hidden);
+    await page.click('#enter-vr');
+    await page.waitForFunction(() => testFrames > 5 && document.querySelector('#help').hidden);
+    await page.evaluate(() => testSession.end());
+    assert.deepEqual(errors, []);
+    console.log(`Quest 3 null headset passed: stereo frames, head tracking, two controllers, snap turn, teleport, exit/re-entry, permission retry, ${buildings} buildings.`);
+    await page.close();
+
+    const desktop = await browser.newPage();
+    await desktop.addInitScript(() => Object.defineProperty(navigator, 'xr', { value: undefined }));
+    await desktop.route('https://overturemaps-extras-us-west-2.s3.amazonaws.com/**', route => route.fulfill({ status: 503, body: 'Unavailable' }));
+    await desktop.goto(url);
+    await desktop.waitForFunction(() => document.querySelector('#xr-status').textContent.includes('VR unavailable'));
+    await desktop.waitForFunction(() => document.querySelector('#building-status').textContent.includes('Buildings unavailable'));
+    assert.equal(await desktop.isDisabled('#enter-vr'), true);
+    assert.equal(await desktop.evaluate(() => helloWorldWebXR.scene.activeCamera.name), 'desktop');
+    console.log('Desktop fallback and unavailable building service passed.');
+} finally {
+    await browser?.close();
+    await new Promise(done => server.close(done));
+}

--- a/examples-npm/hello-world-webxr/tsconfig.json
+++ b/examples-npm/hello-world-webxr/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+        "module": "esNext",
+		"target": "es5",
+		"moduleResolution": "node",
+		"strict": true,
+		"noImplicitAny": true,
+        "noImplicitReturns": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "skipLibCheck": true,
+		"preserveConstEnums":true,
+		"sourceMap": true,
+		//"watch": false,
+		"strictPropertyInitialization": false,
+		"allowSyntheticDefaultImports":true
+	},
+	"files": [
+		"src/index.ts"
+	]
+}

--- a/examples-npm/hello-world-webxr/webpack.common.js
+++ b/examples-npm/hello-world-webxr/webpack.common.js
@@ -1,0 +1,51 @@
+const path = require('path');
+const fs = require('fs');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const {
+    CleanWebpackPlugin
+} = require('clean-webpack-plugin');
+
+// App directory
+const appDirectory = fs.realpathSync(process.cwd());
+
+module.exports = {
+    resolve: {
+        extensions: ['.ts', '.js']
+    },
+    output: {
+        filename: 'js/babylonBundle.js',
+        library: { name: 'helloWorldWebXR', type: 'window' },
+        path: path.resolve("./dist/")
+    },
+    module: {
+        rules: [{
+                test: /\.(js|mjs|jsx|ts|tsx)$/,
+                loader: 'source-map-loader',
+                enforce: 'pre',
+            },
+            { //per https://stackoverflow.com/questions/70964723/webpack-5-in-ceate-react-app-cant-resolve-not-fully-specified-routes
+                test: /\.m?js$/,
+                resolve: {
+                    fullySpecified: false,
+                },
+            },
+            { 
+                test: /\.tsx?$/,
+                loader: 'ts-loader',
+                exclude: /node_modules/
+            },
+            {
+                test: /\.(png|jpg|gif|env|glb|stl)$/i,
+                type: 'asset',
+                parser: { dataUrlCondition: { maxSize: 8192 } },
+            }
+        ]
+    },
+    plugins: [
+        new CleanWebpackPlugin(),
+        new HtmlWebpackPlugin({
+            inject: true,
+            template: path.resolve(appDirectory, "index.html"),
+        }),
+    ],
+}

--- a/examples-npm/hello-world-webxr/webpack.config-dev.js
+++ b/examples-npm/hello-world-webxr/webpack.config-dev.js
@@ -1,0 +1,15 @@
+const { merge } = require('webpack-merge');
+const path = require('path');
+const common = require('./webpack.common.js');
+module.exports = merge(common, {
+    mode: 'development',
+    devtool: 'source-map',
+    devServer: {
+        host: '0.0.0.0',
+        port: 8080,
+        static: path.resolve(__dirname, 'public'),
+        // For Quest: npm start -- --server-type https, then trust the certificate.
+        // The deployed GitHub Pages demo already uses HTTPS.
+        server: 'http',
+    },
+});

--- a/examples-npm/hello-world-webxr/webpack.config-prod.js
+++ b/examples-npm/hello-world-webxr/webpack.config-prod.js
@@ -1,0 +1,7 @@
+const { merge } = require('webpack-merge')
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  mode: 'production',
+  devtool: 'source-map'
+});


### PR DESCRIPTION
Adds a separate Hello World WebXR demo with a 4-metre miniature Duke campus, OSM raster tiles, and key-free Overture buildings. Quest controllers support teleportation and snap turning; instructions and attribution remain visible inside VR. Desktop fallback, permission-denial retry, and session exit/re-entry are supported. The demo is included in the Pages build and demo launcher.

The existing Hello World building fix was committed separately to `main` as 28dc7c1 and has deployed successfully. This PR contains only the immersive example and its integration.

Validation:
- 148 library tests passed.
- Production demo build passed (Webpack bundle-size warnings only).
- Playwright with Meta IWER's Quest 3 null headset passed stereo eye rendering, head translation/rotation, both controllers, snap turn, teleport movement, permission retry, exit/re-entry, and loading 337 buildings.
- Desktop fallback and simulated building-service failure passed.

To repeat the headset test, build and pack the current root library, install that tarball in `examples-npm/hello-world-webxr`, then run `npm run build`, `npx playwright install chromium`, and `npm run test:xr` there. The test uses live public map/building data. `npm start` serves localhost; Quest Browser requires HTTPS (the deployed Pages site, or `npm start -- --server-type https` with a trusted certificate).

Testing used a simulated headset as requested; physical Quest 3 performance and comfort have not been measured.

Closes #80.
